### PR TITLE
adding energy forces and stress to ase.Atoms

### DIFF
--- a/fpdataviewer/mlab/ase_adapter.py
+++ b/fpdataviewer/mlab/ase_adapter.py
@@ -1,17 +1,32 @@
 from __future__ import annotations
 
 from ase import Atoms
+from ase.stress import voigt_6_to_full_3x3_stress
 
 from fpdataviewer.mlab.mlab import MLABSection, MLABConfiguration, MLAB
 
 
 def from_configuration(conf: MLABConfiguration) -> Atoms:
-    return Atoms(
-        symbols=conf.generate_type_lookup(),
-        positions=conf.positions,
-        cell=conf.lattice_vectors,
-        pbc=True,
-    )
+    atoms = Atoms(
+              symbols=conf.generate_type_lookup(),
+              positions=conf.positions,
+              cell=conf.lattice_vectors,
+              pbc=True,
+             )
+
+    if conf.energy is not None:
+          atoms.info["energy"]=conf.energy 
+    if conf.forces is not None:
+          atoms.arrays['forces']=conf.forces
+    if conf.stress is not None:
+          atoms.info["stress"]=voigt_6_to_full_3x3_stress([conf.stress.xx,
+                                                           conf.stress.yy,
+                                                           conf.stress.zz, 
+                                                           conf.stress.yz, 
+                                                           conf.stress.zx, 
+                                                           conf.stress.xy])
+ 
+    return atoms
 
 def from_section(section: MLABSection) -> list[Atoms]:
     atoms = section.generate_type_lookup()


### PR DESCRIPTION
Useful to create extxyz files with energies, forces and stress for ML
for example:
fpdataviewer convert -i  ML_ABN  -o filename.extxyz  -f vasp-mlab 